### PR TITLE
Fix server error on insufficient permissions && Fix cropped item move handle for long title

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -876,6 +876,7 @@
         [is=listling-item] .micro-ol-handle {
             padding: calc(1.5em / 4);
             width: calc(1.5em / 2 + 1.5em / 2);
+            min-width: calc(1.5em / 2 + 1.5em / 2);
             height: calc(1.5em + 1.5em / 2);
             background:
                 radial-gradient(circle closest-side, #888 0%, #888 50%, transparent 50%) content-box

--- a/listling/listling.py
+++ b/listling/listling.py
@@ -128,7 +128,7 @@ class Listling(Application):
             # pylint: disable=unused-argument; former feature toggle
             # Compatibility for endpoint version (deprecated since 0.22.0)
             if not self.app.user:
-                raise PermissionError()
+                raise micro.PermissionError()
             if use_case not in _USE_CASES:
                 raise micro.ValueError('use_case_unknown')
 
@@ -242,7 +242,7 @@ class User(micro.User):
         def add(self, lst, *, user):
             """See: :http:post:`/users/(id)/lists`."""
             if user != getattr(self, 'user'):
-                raise PermissionError()
+                raise micro.PermissionError()
             self.app.r.zadd(self.ids.key, {lst.id: -time()})
 
         def remove(self, lst, *, user):
@@ -251,7 +251,7 @@ class User(micro.User):
             If *lst* is not in the collection, a :exc:`micro.error.ValueError` is raised.
             """
             if user != getattr(self, 'user'):
-                raise PermissionError()
+                raise micro.PermissionError()
             if lst.authors[0] == getattr(self, 'user'):
                 raise micro.ValueError(
                     'user {} is owner of lst {}'.format(getattr(self, 'user').id, lst.id))
@@ -262,7 +262,7 @@ class User(micro.User):
         def read(self, *, user):
             """Return collection for reading."""
             if user != getattr(self, 'user'):
-                raise PermissionError()
+                raise micro.PermissionError()
             return self
 
     def __init__(self, *, app, **data):
@@ -438,7 +438,7 @@ class Item(Object, Editable, Trashable, WithContent):
         def vote(self, *, user):
             """See :http:post:`/api/lists/(list-id)/items/(id)/votes`."""
             if not user:
-                raise PermissionError()
+                raise micro.PermissionError()
             if 'vote' not in self.item.list.features:
                 raise error.ValueError('Disabled item list features vote')
             if self.app.r.zadd(self.ids.key, {user.id.encode(): -time()}):
@@ -448,7 +448,7 @@ class Item(Object, Editable, Trashable, WithContent):
         def unvote(self, *, user):
             """See :http:delete:`/api/lists/(list-id)/items/(id)/votes/user`."""
             if not user:
-                raise PermissionError()
+                raise micro.PermissionError()
             if 'vote' not in self.item.list.features:
                 raise error.ValueError('Disabled item list features vote')
             if self.app.r.zrem(self.ids.key, user.id.encode()):
@@ -557,4 +557,4 @@ def _check_feature(user, feature, item):
     if feature not in item.list.features:
         raise micro.ValueError('feature_disabled')
     if not user:
-        raise PermissionError()
+        raise micro.PermissionError()


### PR DESCRIPTION
Replaced `PermissionError` (builtin) with `micro.PermissionError`.