### PR TITLE
feat(lists): Add item tempalte functionality to lists

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -343,6 +343,13 @@
                             </template>
                         </micro-options>
                     </label>
+
+                    <label>
+                        Item template
+                        <textarea name="item_template" placeholder="Enter text that new items should start with (optional)"
+                          data-value="or lst.item_template ''">
+                        </textarea>
+                    </label>
                 </section>
             </div>
 

--- a/client/index.html
+++ b/client/index.html
@@ -349,6 +349,7 @@
                         <textarea name="item_template" placeholder="Enter text that new items should start with (optional)"
                           data-value="or lst.item_template ''">
                         </textarea>
+                        <small>New items will be created with this description</small>
                     </label>
                 </section>
             </div>

--- a/client/listling/index.js
+++ b/client/listling/index.js
@@ -156,8 +156,9 @@ listling.ListPage = class extends micro.Page {
                 this._data.creatingItem = true;
                 this.querySelector(".listling-list-create-item [is=listling-item]").focus();
                 this.querySelector(".listling-list-create-item [is=listling-item]").scrollIntoView(false);
+                // Find the new ItemElement and pass the item_template to it
                 const elem = this.querySelector(".listling-list-create-item [is=listling-item]");
-                elem.startCreate(this._form.elements.item_template.value);
+                elem.startCreate(this._data.lst.item_template);
             },
             stopCreateItem: () => {
                 this._data.creatingItem = false;
@@ -418,6 +419,11 @@ listling.ListPage._PERMISSIONS = {
 
 listling.ItemElement = class extends HTMLLIElement {
 
+    /*
+        Called by ListPage when the "add item" button is clicked.
+        Receives the template text for new items as it's only parameter and
+        fills the textarea with it.
+    */
     startCreate(templateText) {
         this.querySelector("textarea").value = templateText;
     }

--- a/client/listling/index.js
+++ b/client/listling/index.js
@@ -156,6 +156,8 @@ listling.ListPage = class extends micro.Page {
                 this._data.creatingItem = true;
                 this.querySelector(".listling-list-create-item [is=listling-item]").focus();
                 this.querySelector(".listling-list-create-item [is=listling-item]").scrollIntoView(false);
+                const elem = this.querySelector(".listling-list-create-item [is=listling-item]");
+                elem.startCreate(this._form.elements.item_template.value);
             },
             stopCreateItem: () => {
                 this._data.creatingItem = false;
@@ -177,7 +179,8 @@ listling.ListPage = class extends micro.Page {
                         features:
                             Array.from(this._form.elements.features, e => e.checked && e.value)
                                 .filter(feature => feature),
-                        mode: this._form.elements.mode.valueAsObject
+                        mode: this._form.elements.mode.valueAsObject,
+                        item_template: this._form.elements.item_template.value
                     });
                     if (this._data.lst) {
                         this.list = list;
@@ -414,6 +417,11 @@ listling.ListPage._PERMISSIONS = {
 };
 
 listling.ItemElement = class extends HTMLLIElement {
+
+    startCreate(templateText) {
+        this.querySelector("textarea").value = templateText;
+    }
+
     createdCallback() {
         this.appendChild(
             document.importNode(ui.querySelector(".listling-item-template").content, true));

--- a/listling/listling.py
+++ b/listling/listling.py
@@ -183,7 +183,7 @@ class Listling(Application):
     def do_update(self):
         version = self.r.get('version')
         if not version:
-            self.r.set('version', 8)
+            self.r.set('version', 9)
             return
 
         version = int(version)
@@ -209,6 +209,13 @@ class Listling(Application):
                     t = parse_isotime(event['time'], aware=True).timestamp()
                     self.r.zadd(users_key, {event['user'].encode(): -t})
             r.set('version', 8)
+
+        if version < 9:
+            lists = r.omget(r.lrange('lists', 0, -1))
+            for lst in lists:
+                lst['item_template'] = None
+            r.omset({l["id"]: l for l in lists})
+            r.set('version', 9)
 
     def create_user(self, data):
         return User(**data)

--- a/listling/listling.py
+++ b/listling/listling.py
@@ -312,13 +312,15 @@ class List(Object, Editable):
             self.host[0]._check_permission(self.app.user, 'list-modify')
             super().move(item, to)
 
-    def __init__(self, *, id, app, authors, title, description, features, mode, activity):
+    def __init__(self, *, id, app, authors, title, description, features, mode, activity,
+                 item_template=None):
         super().__init__(id=id, app=app)
         Editable.__init__(self, authors=authors, activity=activity)
         self.title = title
         self.description = description
         self.features = features
         self.mode = mode
+        self.item_template = item_template
         self.items = List.Items((self, 'items'))
         self.activity = activity
         self.activity.post = self._on_activity_publish
@@ -359,6 +361,8 @@ class List(Object, Editable):
             self.title = attrs['title']
         if 'description' in attrs:
             self.description = str_or_none(attrs['description'])
+        if 'item_template' in attrs:
+            self.item_template = str_or_none(attrs['item_template'])
         if 'features' in attrs:
             self.features = attrs['features']
         if 'mode' in attrs:
@@ -370,6 +374,7 @@ class List(Object, Editable):
             **Editable.json(self, restricted=restricted, include=include, rewrite=rewrite),
             'title': self.title,
             'description': self.description,
+            'item_template': self.item_template,
             'features': self.features,
             'mode': self.mode,
             'activity': self.activity.json(restricted=restricted, rewrite=rewrite),

--- a/listling/server.py
+++ b/listling/server.py
@@ -113,6 +113,7 @@ class _ListEndpoint(Endpoint):
         args = self.check_args({
             'title': (str, 'opt'),
             'description': (str, None, 'opt'),
+            'item_template': (str, None, 'opt'),
             'features': (list, 'opt'),
             'mode': (str, 'opt')
         })

--- a/listling/tests/test_listling.py
+++ b/listling/tests/test_listling.py
@@ -119,6 +119,9 @@ class ListlingUpdateTest(AsyncTestCase):
         # Update to version 8
         self.assertEqual([user.id for user in app.lists[1].users()],
                          [user.id for user in reversed(app.users[0:2])])
+        # Update to version 9
+        for l in app.lists.values(): # pylint: disable=no-member
+            self.assertEqual(l.item_template, None)
 
 class UserListsTest(ListlingTestCase):
     def test_add(self):

--- a/listling/tests/test_listling.py
+++ b/listling/tests/test_listling.py
@@ -144,9 +144,10 @@ class UserListsTest(ListlingTestCase):
 class ListTest(ListlingTestCase):
     def test_edit(self):
         lst = self.app.lists.create(v=2)
-        lst.edit(description='What has to be done!', mode='view')
+        lst.edit(description='What has to be done!', mode='view', item_template="A template")
         self.assertEqual(lst.description, 'What has to be done!')
         self.assertEqual(lst.mode, 'view')
+        self.assertEqual(lst.item_template, 'A template')
 
     def test_edit_as_user(self):
         lst = self.app.lists.create(v=2)
@@ -160,6 +161,18 @@ class ListTest(ListlingTestCase):
         self.app.login()
         with self.assertRaises(micro.PermissionError):
             lst.edit(description='What has to be done!')
+
+    def test_json(self):
+        lst = self.app.lists.create(v=2)
+        lst.edit(
+            title="A list to rule all lists",
+            description="It's all in the title",
+            item_template="An item to rule all items",
+        )
+        data = lst.json()
+        self.assertEqual(data['title'], "A list to rule all lists")
+        self.assertEqual(data['description'], "It's all in the title")
+        self.assertEqual(data['item_template'], "An item to rule all items")
 
     @gen_test
     async def test_query_users_name(self):

--- a/micro/client/micro.css
+++ b/micro/client/micro.css
@@ -341,6 +341,11 @@ textarea {
 
 label {
     display: block;
+    margin: 1.5rem 0;
+}
+
+fieldset > label {
+    margin: 0;
 }
 
 h1 > label {
@@ -354,10 +359,6 @@ label > small {
 
 label > small:first-of-type {
     color: inherit;
-}
-
-form > label {
-    margin: 1.5rem 0;
 }
 
 .compact form > label {


### PR DESCRIPTION
  The "more settings" section of a list now has a new textarea
  where users can define an item tempalate.
  New item's descriptions are then pre-filled with this.